### PR TITLE
New

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # astrbot_plugin_extract
 
-_✨ 解析插件 ✨_  
+_✨ 元数据解析 ✨_  
 
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0.html)
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-blue.svg)](https://www.python.org/)
@@ -16,11 +16,11 @@ _✨ 解析插件 ✨_
 
 ## 🤝 介绍
 
-对文本、图片、视频、语音、文件等进行信息提取并解析
+对图片、视频、语音、文件等媒体的元数据进行解析
 
 ## 📦 安装
 
-- 在astrbot的插件市场搜索astrbot_plugin_extract，点击安装，耐心等待安装完成即可
+在astrbot的插件市场搜索astrbot_plugin_extract，点击安装即可
 
 ## ⌨️ 使用说明
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -9,12 +9,14 @@
             "audio"
         ],
         "default": [
-            "image"
+            "image",
+            "video",
+            "audio"
         ]
     },
     "enable_geo_resolver": {
         "description": "逆解析GPS的地理信息",
-        "hint":"需要代理",
+        "hint": "需要代理",
         "type": "bool",
         "default": false
     },

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_extract
-display_name: 解析插件
-desc: 对文本、图片、视频、语音、文件等进行信息提取并解析
+display_name: 媒体元数据解析
+desc: 对图片、视频、语音、文件等媒体的元数据进行解析
 version: v1.0.0
 author: Zhalslar
 repo: https://github.com/Zhalslar/astrbot_plugin_extract


### PR DESCRIPTION
## Summary by Sourcery

更新插件元数据和 README，明确说明该插件专注于解析媒体元数据，而不是进行通用内容抽取。

文档：
- 在 README 中澄清描述，说明插件是用于解析媒体文件的元数据，而不是执行通用信息抽取。
- 在 README 中简化安装说明，以便从 astrbot 插件市场安装该插件。

杂项：
- 调整 `metadata.yaml` 中的显示名称和描述，使其与插件专注于媒体元数据解析的更新定位保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update plugin metadata and README to clarify that the plugin focuses on parsing media metadata rather than general content extraction.

Documentation:
- Clarify README description to state the plugin parses metadata for media files instead of performing general information extraction.
- Simplify installation instructions in the README for installing the plugin from the astrbot plugin marketplace.

Chores:
- Align metadata.yaml display name and description with the updated focus on media metadata parsing.

</details>